### PR TITLE
Create upsource home directory to prevent upsource-analyzer maven module to crash.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ MAINTAINER Eugene Volchek <evolchek@klika-tech.com>
 
 ENV UPSOURCE_VERSION 1.0.12566
 WORKDIR /opt
-RUN groupadd -g 999 upsource && useradd -u 999 -g upsource upsource && \
-	wget -nv http://download.jetbrains.com/upsource/upsource-$UPSOURCE_VERSION.zip && \
+RUN mkdir -p /home/upsource && groupadd -g 999 upsource && useradd -u 999 -g upsource -d /home/upsource upsource && \
+	chown -R upsource:upsource /home/upsource
+RUN wget -nv http://download.jetbrains.com/upsource/upsource-$UPSOURCE_VERSION.zip && \
 	unzip upsource-$UPSOURCE_VERSION.zip && \
 	rm -rf upsource-$UPSOURCE_VERSION.zip && \
 	chown -R upsource:upsource Upsource


### PR DESCRIPTION
When creating an upsource project using maven, upsource-analyzer throw exception because it can read upsource user home directory

```
[Upsource Analyzer Error] java.lang.ExceptionInInitializerError
[Upsource Analyzer Error]   at com.jetbrains.upsource.backend.server.maven.MavenSupport.processProjectRevision(MavenSupport.java:85)
[Upsource Analyzer Error]   at com.jetbrains.upsource.backend.cli.stages.driver.impl.MavenSupportDriver.analyze(MavenSupportDriver.java:57)
[Upsource Analyzer Error]   at com.jetbrains.upsource.backend.cli.stages.driver.DriverWrapper.analyze(DriverWrapper.java:61)
[Upsource Analyzer Error]   at com.jetbrains.upsource.backend.cli.stages.driver.IndexerPipelineRunner.iterateOnce(IndexerPipelineRunner.java:80)
[Upsource Analyzer Error]   at com.jetbrains.upsource.backend.cli.stages.driver.IndexerPipelineRunner.access$100(IndexerPipelineRunner.java:22)
[Upsource Analyzer Error]   at com.jetbrains.upsource.backend.cli.stages.driver.IndexerPipelineRunner$1.execute(IndexerPipelineRunner.java:53)
[Upsource Analyzer Error]   at com.jetbrains.upsource.backend.cli.stages.driver.IndexerPipelineRunner$1.execute(IndexerPipelineRunner.java:49)
[Upsource Analyzer Error]   at com.jetbrains.upsource.lifetimes.LifetimeImpl.runSync(LifetimeImpl.java:75)
[Upsource Analyzer Error]   at com.jetbrains.upsource.backend.cli.stages.driver.IndexerPipelineRunner.indexTasks(IndexerPipelineRunner.java:49)
[Upsource Analyzer Error]   at com.jetbrains.upsource.backend.cli.multi.revisions.DriverClusterPipelineImpl$2.run(DriverClusterPipelineImpl.java:120)
[Upsource Analyzer Error]   at com.jetbrains.upsource.backend.cli.multi.tasks.MultiProjectTaskFactory$TaskExecutor$2.run(MultiProjectTaskFactory.java:175)
[Upsource Analyzer Error]   at __.project_wap.__(JavaGeneratorTemplate.java:44)
[Upsource Analyzer Error]   at org.jonnyzzz.stack.NamedStackFrame.frame(NamedStackFrame.java:48)
[Upsource Analyzer Error]   at com.jetbrains.upsource.backend.cli.multi.tasks.MultiProjectTaskFactory$TaskExecutor.executeTask(MultiProjectTaskFactory.java:172)
[Upsource Analyzer Error]   at com.jetbrains.upsource.backend.cli.multi.tasks.MultiProjectTaskFactory$TaskExecutor$1.run(MultiProjectTaskFactory.java:153)
[Upsource Analyzer Error]   at com.jetbrains.upsource.backend.cli.multi.executor.ProjectSyncExecutor$ProjectTasks$1$1.run(ProjectSyncExecutor.java:219)
[Upsource Analyzer Error]   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
[Upsource Analyzer Error]   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
[Upsource Analyzer Error]   at java.lang.Thread.run(Thread.java:745)
[Upsource Analyzer Error] Caused by: java.lang.RuntimeException: java.nio.file.NoSuchFileException: /home/upsource
[Upsource Analyzer Error]   at com.jetbrains.upsource.backend.server.maven.MavenSupportUtil.<clinit>(MavenSupportUtil.java:49)
[Upsource Analyzer Error]   ... 19 more
[Upsource Analyzer Error] Caused by: java.nio.file.NoSuchFileException: /home/upsource
[Upsource Analyzer Error]   at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
[Upsource Analyzer Error]   at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
[Upsource Analyzer Error]   at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
[Upsource Analyzer Error]   at sun.nio.fs.UnixPath.toRealPath(UnixPath.java:837)
[Upsource Analyzer Error]   at com.jetbrains.upsource.backend.server.maven.MavenSupportUtil.<clinit>(MavenSupportUtil.java:47)
[Upsource Analyzer Error]   ... 19 more
```

I just add a `RUN` to create upsource directory to avoid any maven problem.
