### PR TITLE
Updated to upsource 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM java:openjdk-8-jre
 
 MAINTAINER Eugene Volchek <evolchek@klika-tech.com>
 
-ENV UPSOURCE_VERSION 2.5.4995
+ENV UPSOURCE_VERSION 3.0.4291
 VOLUME ["/opt/Upsource/conf", "/opt/Upsource/data", "/opt/Upsource/logs", "/opt/Upsource/backups"]
 WORKDIR /opt
 RUN mkdir -p /home/upsource \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /home/upsource \
 	&& useradd -u 999 -g upsource -d /home/upsource upsource \
 	&& chown -R upsource:upsource /home/upsource \
 	&& wget -nv http://download.jetbrains.com/upsource/upsource-$UPSOURCE_VERSION.zip \
-	&& unzip upsource-$UPSOURCE_VERSION.zip \
+	&& unzip upsource-$UPSOURCE_VERSION.zip -d /opt/Upsource \
 	&& rm -rf upsource-$UPSOURCE_VERSION.zip \
 	&& chown -R upsource:upsource Upsource
 USER upsource


### PR DESCRIPTION
Updated to Upsource 3. 
Unfortunately Jetbrains have removed the /Upsource folder from inside the tar file.
